### PR TITLE
Make URL configs and middlewares work on Django 2.0

### DIFF
--- a/src/web/frontend/urls.py
+++ b/src/web/frontend/urls.py
@@ -2,6 +2,8 @@ from django.conf.urls import url
 
 from . import views
 
+app_name = 'frontend'
+
 urlpatterns = [
     url(r'^table/(?P<table_name>[^/]+)/data/$', views.table_data, name='table_data'),
 ]

--- a/src/web/modules/ejudge/admin.py
+++ b/src/web/modules/ejudge/admin.py
@@ -18,7 +18,7 @@ class QueueElementAdminForm(django.forms.ModelForm):
         fields = ('__all__')
         widgets = {
             'submission': autocomplete.ModelSelect2(
-                url='ejudge:admin:submission-autocomplete')
+                url='ejudge:submission-autocomplete')
         }
 
 
@@ -75,7 +75,7 @@ class SubmissionAdminForm(django.forms.ModelForm):
         fields = ('__all__')
         widgets = {
             'result': autocomplete.ModelSelect2(
-                url='ejudge:admin:solution-checking-result-autocomplete')
+                url='ejudge:solution-checking-result-autocomplete')
         }
 
 

--- a/src/web/modules/ejudge/school_urls.py
+++ b/src/web/modules/ejudge/school_urls.py
@@ -2,6 +2,8 @@ from django.conf.urls import url
 
 from modules.ejudge.staff import views as staff_views
 
+app_name = 'ejudge'
+
 
 urlpatterns = [
     url(r'^stats/$', staff_views.show_ejudge_stats, name='show_ejudge_stats'),

--- a/src/web/modules/ejudge/urls.py
+++ b/src/web/modules/ejudge/urls.py
@@ -2,6 +2,8 @@ from django.conf.urls import include, url
 
 from modules.ejudge import views
 
+app_name = 'ejudge'
+
 
 admin_urlpatterns = [
     url(r'^submission-autocomplete/$',
@@ -14,5 +16,5 @@ admin_urlpatterns = [
 
 
 urlpatterns = [
-    url(r'^admin/', include(admin_urlpatterns, namespace='admin')),
+    url(r'^admin/', include(admin_urlpatterns)),
 ]

--- a/src/web/modules/enrolled_scans/urls.py
+++ b/src/web/modules/enrolled_scans/urls.py
@@ -1,6 +1,8 @@
 from django.conf.urls import url
 from . import views
 
+app_name = 'enrolled_scans'
+
 urlpatterns = [
     url(r'^$', views.scans, name='scans'),
     url(r'^(?P<requirement_name>.+)/$', views.scan, name='scan')

--- a/src/web/modules/entrance/staff/urls.py
+++ b/src/web/modules/entrance/staff/urls.py
@@ -11,7 +11,7 @@ urlpatterns = [
         name='enrolling_user'),
     url(r'^enrolling/(?P<user_id>\d+)/profile/$',
         views.user_profile,
-        name='user_profile'),
+        name='user-profile'),
     url(r'^enrolling/(?P<user_id>\d+)/questionnaire/'
         '(?P<questionnaire_name>[^/]+)/$',
         views.user_questionnaire,

--- a/src/web/modules/entrance/templates/entrance/staff/check_user.html
+++ b/src/web/modules/entrance/templates/entrance/staff/check_user.html
@@ -181,7 +181,7 @@
                 <div class="panel-heading">
                     <span class="panel-title">Общая информация</span>
                     <div class="mr10 pull-right fs12">
-                        <a href="{% url 'school:entrance:user_profile' request.school.short_name user_for_checking.id %}"
+                        <a href="{% url 'school:entrance:user-profile' request.school.short_name user_for_checking.id %}"
                            target="_blank" class="ml10" title="Откроется в новой вкладке">
                             Профиль</a>
                         <a href="{% url 'school:entrance:user_questionnaire' request.school.short_name user_for_checking.id 'enrollee' %}"

--- a/src/web/modules/entrance/templates/entrance/steps/confirm_profile.html
+++ b/src/web/modules/entrance/templates/entrance/steps/confirm_profile.html
@@ -3,7 +3,7 @@
 {% block title %}Подтвердить профиль{% endblock %}
 
 {% block not_passed_after_text %}
-    <a href="{% url 'user:profile' %}?confirm=1" class="btn btn-primary">
+    <a href="{% url 'user-profile' %}?confirm=1" class="btn btn-primary">
         {% block not_passed_button_text %}
             Проверить <span class="visible-xs-inline">профиль</span><span class="hidden-xs">и&nbsp;подтвердить информацию в&nbsp;профиле</span>
         {% endblock %}

--- a/src/web/modules/entrance/templates/entrance/steps/ensure_profile_is_full.html
+++ b/src/web/modules/entrance/templates/entrance/steps/ensure_profile_is_full.html
@@ -3,7 +3,7 @@
 {% block title %}Заполнить все необходимые поля в&nbsp;профиле{% endblock %}
 
 {% block not_passed_after_text %}
-    <a href="{% url 'user:profile' %}?full=1" class="btn btn-primary">
+    <a href="{% url 'user-profile' %}?full=1" class="btn btn-primary">
         {% block not_passed_button_text %}
             Заполнить профиль
         {% endblock %}

--- a/src/web/modules/entrance/urls.py
+++ b/src/web/modules/entrance/urls.py
@@ -2,6 +2,8 @@ from django.conf.urls import url, include
 from . import views
 from .staff import views as staff_views
 
+app_name = 'entrance'
+
 urlpatterns = [
     url(r'^exam/$', views.exam, name='exam'),
     url(r'^exam/solution/(?P<solution_id>\d+)/$', views.solution, name='solution'),

--- a/src/web/modules/finance/urls.py
+++ b/src/web/modules/finance/urls.py
@@ -2,6 +2,9 @@ from django.conf.urls import url
 
 from . import views
 
+app_name = 'finance'
+
+
 urlpatterns = [
     url(r'^(?P<document_type>[^/]+)/$', views.download, name='download'),
     ]

--- a/src/web/modules/poldnev/urls.py
+++ b/src/web/modules/poldnev/urls.py
@@ -2,6 +2,8 @@ from django.conf.urls import url
 
 from modules.poldnev import views
 
+app_name = 'poldnev'
+
 
 urlpatterns = [
     url(

--- a/src/web/modules/smartq/urls.py
+++ b/src/web/modules/smartq/urls.py
@@ -1,6 +1,8 @@
 from django.conf.urls import url, include
 from modules.smartq import views
 
+app_name = 'smartq'
+
 urlpatterns = [
     url(r'^(?P<question_short_name>[^/]+)/', include([
         url(r'^$',

--- a/src/web/modules/study_results/school_urls.py
+++ b/src/web/modules/study_results/school_urls.py
@@ -1,6 +1,9 @@
 from django.conf.urls import url
 from modules.study_results.staff import views as staff_views
 
+app_name = 'study_results'
+
+
 urlpatterns = [
     # Staff urls
     url(r'^$', staff_views.study_results, name='study_results'),

--- a/src/web/modules/study_results/urls.py
+++ b/src/web/modules/study_results/urls.py
@@ -1,6 +1,8 @@
 from django.conf.urls import url
 from modules.study_results.staff import views as staff_views
 
+app_name = 'study_results'
+
 urlpatterns = [
     # Staff urls
     url(r'^user/(?P<user_id>\d+)/$',

--- a/src/web/modules/topics/urls.py
+++ b/src/web/modules/topics/urls.py
@@ -2,6 +2,9 @@ from django import conf
 from django.conf.urls import url
 from . import views
 
+app_name = 'topics'
+
+
 urlpatterns = [
     url(r'^$', views.index, name='index'),
     url(r'^checking/$', views.check_topics, name='check_topics'),

--- a/src/web/questionnaire/urls.py
+++ b/src/web/questionnaire/urls.py
@@ -3,6 +3,9 @@ from django.conf.urls import url
 
 from . import views
 
+app_name = 'questionnaire'
+
+
 urlpatterns = [
     url(r'^(?P<questionnaire_name>[^/]+)/$', views.questionnaire, name='questionnaire'),
 ]

--- a/src/web/schools/middleware.py
+++ b/src/web/schools/middleware.py
@@ -1,8 +1,10 @@
 from django import shortcuts, http
+from django.utils.deprecation import MiddlewareMixin
+
 from schools import models as school_models
 
 
-class SchoolMiddleware(object):
+class SchoolMiddleware(MiddlewareMixin):
     def process_view(self, request, view_func, view_args, view_kwargs):
         if 'school_name' in view_kwargs:
             request.school = shortcuts.get_object_or_404(

--- a/src/web/schools/urls.py
+++ b/src/web/schools/urls.py
@@ -2,6 +2,8 @@ from django.conf.urls import url, include
 
 from schools import views
 
+app_name = 'schools'
+
 urlpatterns = [
     url(r'^(?P<school_name>[^/]+)/', include([
         url(r'^$', views.index, name='index'),

--- a/src/web/sistema/settings.py
+++ b/src/web/sistema/settings.py
@@ -105,7 +105,7 @@ INSTALLED_APPS = (
     'modules.topics',
 )
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'htmlmin.middleware.HtmlMinifyMiddleware',
     'htmlmin.middleware.MarkRequestMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',

--- a/src/web/sistema/templates/_staff_header.html
+++ b/src/web/sistema/templates/_staff_header.html
@@ -46,7 +46,7 @@
                     </a>
                 </li>
                 <li class="list-group-item">
-                    <a href="{% url "user:profile" %}">
+                    <a href="{% url "user-profile" %}">
                         <span class="fa fa-user"></span> Профиль
                     </a>
                 </li>

--- a/src/web/sistema/templates/user_layout.html
+++ b/src/web/sistema/templates/user_layout.html
@@ -61,7 +61,7 @@
                                 </li>
                             {% endif %}
                             <li class="list-group-item">
-                                <a href="{% url "user:profile" %}">
+                                <a href="{% url "user-profile" %}">
                                     <span class="fa fa-user"></span> Профиль
                                 </a>
                             </li>

--- a/src/web/sistema/urls.py
+++ b/src/web/sistema/urls.py
@@ -10,7 +10,7 @@ import django_nyt.urls
 
 urlpatterns = [
     url(r'', include('home.urls')),
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', admin.site.urls),
     url(r'^ejudge/', include('modules.ejudge.urls', namespace='ejudge')),
     url(r'^questionnaire/', include('questionnaire.urls')),
     url(r'^frontend/', include('frontend.urls', namespace='frontend')),

--- a/src/web/users/admin.py
+++ b/src/web/users/admin.py
@@ -61,5 +61,5 @@ class UserAutocompleteModelAdminMixIn(AutocompleteModelAdminMixIn):
         via Select2 with autocomplete """
 
     object_model = models.User
-    url = 'users_admin:user-autocomplete'
+    url = 'user-autocomplete'
     placeholder = 'Выберите пользователя'

--- a/src/web/users/middleware.py
+++ b/src/web/users/middleware.py
@@ -1,7 +1,8 @@
 from django import shortcuts, http
+from django.utils.deprecation import MiddlewareMixin
 
 
-class UserProfileMiddleware(object):
+class UserProfileMiddleware(MiddlewareMixin):
     def process_view(self, request, view_func, view_args, view_kwargs):
         request.user_profile = None
         if request.user.is_authenticated:
@@ -9,6 +10,6 @@ class UserProfileMiddleware(object):
                 # It's here to avoid infinity redirects. Only school's views
                 # are redirecting to user's profile.
                 if hasattr(request, 'school'):
-                    redirect_url = shortcuts.resolve_url('user:profile')
+                    redirect_url = shortcuts.resolve_url('user-profile')
                     return http.HttpResponseRedirect(redirect_url)
         return None

--- a/src/web/users/urls.py
+++ b/src/web/users/urls.py
@@ -12,8 +12,6 @@ urlpatterns = [
     url(r'^accounts/settings/$', views.account_settings, name='account_settings'),
     url(r'^accounts/find-similar/$', views.find_similar_accounts, name='account_find_similar'),
     url(r'^accounts/', include('allauth.urls')),
-    url(r'^user/', include([
-        url(r'^profile/$', views.profile, name='profile'),
-    ], namespace='user')),
-    url(r'^users/admin/', include(admin_urlpatterns, namespace='users_admin')),
+    url(r'^user/profile$', views.profile, name='user-profile'),
+    url(r'^users/admin/', include(admin_urlpatterns)),
 ]


### PR DESCRIPTION
This is a quick minimal fix. There is more work to be done once we
switch to Django 2.0, like using `path` instead of `url`.

Part of #363

Теперь при указании namespace (он же instance namespace) в include джанго требует указания app_name (он же application namespace). Его можно указать, определив переменную app_name в модуле urls. Более подробно можно почитать тут: https://docs.djangoproject.com/en/2.0/topics/http/urls/

