### PR TITLE
Added TeX support in wiki via KaTeX

### DIFF
--- a/src/web/sistema/templates/wiki/base.html
+++ b/src/web/sistema/templates/wiki/base.html
@@ -1,4 +1,5 @@
 {% extends "wiki/base_site.html" %}
+{% load sekizai_tags %}
 
 {% block wiki_site_title %} — Вики ЛКШ{% endblock %}
 
@@ -10,4 +11,19 @@
 <ul class="nav navbar-nav">
     <li class="active"><a href="{% url 'wiki:root' %}">Вики</a></li>
 </ul>
+{% addtoblock "js" %}
+    <!-- KaTeX (via CDN) -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/katex.min.css" integrity="sha384-9tPv11A+glH/on/wEu99NVwDPwkMQESOocs/ZGXPoIiLE8MU/qkqUcZ3zzL+6DuH" crossorigin="anonymous">
+    <script src="https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/katex.min.js" integrity="sha384-U8Vrjwb8fuHMt6ewaCy8uqeUXv4oitYACKdB0VziCerzt011iQ/0TqlSlv8MReCm" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/contrib/auto-render.min.js" integrity="sha384-aGfk5kvhIq5x1x5YdvCp4upKZYnA8ckafviDpmWEKp4afOZEqOli7gqSnh8I6enH" crossorigin="anonymous"></script>
+    <script>
+        document.addEventListener("DOMContentLoaded", function() {
+            renderMathInElement(document.body, {
+                delimiters: [
+                    {left: "$$", right: "$$", display: true},
+                    {left: "$", right: "$", display: false}
+            ]});
+        });
+    </script>
+{% endaddtoblock %}
 {% endblock %}


### PR DESCRIPTION
Added support for TeX in wiki by pluggin KaTeX CDN.

Basically I'm just loading KaTeX js files and run [auto-render](https://github.com/Khan/KaTeX/blob/master/contrib/auto-render/README.md). However, finding where to plug this into django wiki was not trivial. Probably there is a better extension place to plug into.

We can also serve KaTeX not from CDN, but from local files, if servind from CDN will create problems on poor internet connection.

TeX formulas in wiki text should be delimited by $ $ for inline and $$ $$ for display formulas.