### PR TITLE
Move to xenial dist in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: python
 cache: pip
 


### PR DESCRIPTION
Это спасёт от использования старого sqlite, несовместимого с новой Джанго, до которой надо обновиться в виду уязвимостей в старой. См. https://travis-ci.org/andgein/SIStema/jobs/514439561