### PR TITLE
Fix regexp for polygon_contest tag in wiki

### DIFF
--- a/src/web/modules/polygon/wiki/mdx/contest.py
+++ b/src/web/modules/polygon/wiki/mdx/contest.py
@@ -3,7 +3,7 @@ from django.template.loader import render_to_string
 
 from modules.polygon import models
 
-CONTEST_TAG_RE = r'(?i)\[polygon_contest\s+id:(?P<contest_id>\d+)*\]'
+CONTEST_TAG_RE = r'(?i)\[polygon_contest\s+id:(?P<contest_id>\d+)\]'
 
 
 class ContestExtension(markdown.Extension):


### PR DESCRIPTION
With the uwanted additional `*` on contest id the incorrect tag with empty contest id  was processed resulting in runtime error